### PR TITLE
Add missing links to `run` block

### DIFF
--- a/deep-dive/monitor/gamma-ramps.md
+++ b/deep-dive/monitor/gamma-ramps.md
@@ -8,7 +8,7 @@ The current gamma ramp of a [`Monitor`](/deep-dive/monitor.md) can be retrieved 
 ```crystal
 gamma_ramp = CrystGLFW::Monitor.primary.gamma_ramp # => CrystGLFW::Monitor::GammaRamp
 ```
-`gamma_ramp` must be called from within a `run` block definition.
+`gamma_ramp` must be called from within a [`run`](/the-run-block.md) block definition.
 
 ## `set_gamma_ramp` and `gamma_ramp=`
 If you'd like to manually set a gamma ramp for a [`Monitor`](/deep-dive/monitor.md), you can do so with `set_gamma_ramp`:

--- a/deep-dive/window/the-clipboard.md
+++ b/deep-dive/window/the-clipboard.md
@@ -13,7 +13,7 @@ puts window.clipboard # prints the contents of the system clipboard to the scree
 
 If the clipboard is empty or not UTF-8 encoded, a `CrystGLFW::Error::FormatUnavailable` will be raised.
 
-`clipboard` must be called from within a `run` block definition.
+`clipboard` must be called from within a [`run`](/the-run-block.md) block definition.
 
 ## `set_clipboard`
 
@@ -35,4 +35,4 @@ window.clipboard = "Hello World!"
 window.clipboard # => "Hello World!"
 ```
 
-Both `clipboard` and `clipboard=` must be called from within a `run` block definition.
+Both `clipboard` and `clipboard=` must be called from within a [`run`](/the-run-block.md) block definition.


### PR DESCRIPTION
I noticed everywhere you mentioned the `run` block you linked to the page. A few places were missing this link.