### PR TITLE
Add intermediate variable for `key`

### DIFF
--- a/deep-dive/keys.md
+++ b/deep-dive/keys.md
@@ -28,7 +28,8 @@ If a `Key` is "printable", then it has an internal name. You can retrieve this n
 
 ```crystal
 window.on_key do |event|
-  puts event.key.name if key.printable?
+  key = event.key
+  puts key.name if key.printable?
 end
 ```
 


### PR DESCRIPTION
The example for `window.on_key` has an undefined variable `key` error. To fix this I've added an intermediate variable like some of the other examples.